### PR TITLE
Fix iOS 8.3 Crash

### DIFF
--- a/RefreshControl/RefreshControl/RefreshView/RefreshBottomView.m
+++ b/RefreshControl/RefreshControl/RefreshView/RefreshBottomView.m
@@ -112,7 +112,7 @@
     [self addConstraints:aList];
     /////////////
     NSLayoutConstraint * tLeft=[NSLayoutConstraint constraintWithItem:self.loadingLabel attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterX multiplier:1 constant:0];
-    NSLayoutConstraint * tTop=[NSLayoutConstraint constraintWithItem:self.loadingLabel attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:0 constant:13];
+    NSLayoutConstraint * tTop=[NSLayoutConstraint constraintWithItem:self.loadingLabel attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:1 constant:0];
     NSLayoutConstraint * tRight=[NSLayoutConstraint constraintWithItem:self.loadingLabel attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeRight multiplier:1 constant:0];
     NSLayoutConstraint * tHeight=[NSLayoutConstraint constraintWithItem:self.loadingLabel attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeHeight multiplier:0 constant:32];
     


### PR DESCRIPTION
The Code running on device with iOS 8.3 will crash.
Exception:
**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '**\* +[NSLayoutConstraint constraintWithItem:attribute:relatedBy:toItem:attribute:multiplier:constant:]: A multiplier of 0 or a nil second item together with a location for the first attribute creates an illegal constraint of a location equal to a constant. Location attributes must be specified in pairs'
I repair it use make the 'multiplier' in 'tTop' change to '1'.
